### PR TITLE
Create ability to face a direction at a tap.

### DIFF
--- a/GameWindow.rb
+++ b/GameWindow.rb
@@ -34,15 +34,11 @@ class GameWindow < Gosu::Window
 
   def update
     time_tick
-      @ruby.move
-      calc_viewport
-    # if !@waiting
-      input_calc
-      @camera.update(@ruby.x, @ruby.y)
-      @menu.update
-    # else
-    #   @camera.update(@ruby.x, @ruby.y)
-    # end
+    calc_viewport
+    @camera.update(@ruby.x, @ruby.y)
+    @menu.update
+    input_calc
+    @ruby.move
   end
 
   def draw
@@ -62,6 +58,7 @@ class GameWindow < Gosu::Window
 
   def set_timer(frames)
     @timer += frames
+    time_tick
   end
 
   def time_tick

--- a/MenuAction.rb
+++ b/MenuAction.rb
@@ -29,7 +29,7 @@ module MenuAction
       @action = :none
     when :kick
       crop.die
-      @message.text = "You are an meanie you killed the crop"
+      @message.text = "You are a meanie you killed the crop"
       @action = :none
     when :laugh
       @message.text = "you are a lonely farmer and sit laughing by yourself until you cry it is really sad"

--- a/Ruby.rb
+++ b/Ruby.rb
@@ -32,35 +32,38 @@ class Ruby
   end
 
   def accelerate(direction)
+    @window.set_timer(5) if direction != @direction
     @direction = direction
-    case direction
-    when :up
-      @expected_tile = @map.tile_at(@current_tile.x, @current_tile.y - 64)
-      if @expected_tile.collidable?
-        @window.fx(:collision)
-      else
-        @vel_y = -2.5 
-      end
-    when :down
-      @expected_tile = @map.tile_at(@current_tile.x, @current_tile.y + 64)
-      if @expected_tile.collidable?
-        @window.fx(:collision)
-      else
-        @vel_y = 2.5 
-      end
-    when :left
-      @expected_tile = @map.tile_at(@current_tile.x - 64, @current_tile.y)
-      if @expected_tile.collidable?
-        @window.fx(:collision)
-      else
-        @vel_x = -2.5 
-      end
-    when :right
-      @expected_tile = @map.tile_at(@current_tile.x + 64, @current_tile.y)
-      if @expected_tile.collidable?
-        @window.fx(:collision)
-      else
-        @vel_x = 2.5 
+    if !@window.waiting
+      case direction
+      when :up
+        @expected_tile = @map.tile_at(@current_tile.x, @current_tile.y - 64)
+        if @expected_tile.collidable?
+          @window.fx(:collision)
+        else
+          @vel_y = -2.5 
+        end
+      when :down
+        @expected_tile = @map.tile_at(@current_tile.x, @current_tile.y + 64)
+        if @expected_tile.collidable?
+          @window.fx(:collision)
+        else
+          @vel_y = 2.5 
+        end
+      when :left
+        @expected_tile = @map.tile_at(@current_tile.x - 64, @current_tile.y)
+        if @expected_tile.collidable?
+          @window.fx(:collision)
+        else
+          @vel_x = -2.5 
+        end
+      when :right
+        @expected_tile = @map.tile_at(@current_tile.x + 64, @current_tile.y)
+        if @expected_tile.collidable?
+          @window.fx(:collision)
+        else
+          @vel_x = 2.5 
+        end
       end
     end
   end
@@ -116,6 +119,6 @@ class Ruby
     else
       img = @cur_frame
     end
-    img.draw(320, 320, 2, 4, 4)
+    img.draw(321, 321, 2, 4, 4)
   end
 end


### PR DESCRIPTION
Used @window's timer to accomplish this; everytime the directional input is calculated, it sets a short timer for 5 ticks (1/12 second) before reading any more input. This creates a very slight but barely noticeable delay when a player is holding down a directional button, but allows for a light tap to just change facing direction. Note this delay is ONLY set if the player is NOT already facing that direction.

Also did a bit of cleaning up in relevant methods, mostly deleting unused code.
